### PR TITLE
Fix i2c addressing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,7 @@ xG-package = []
 
 rt = ["stm32wb-pac/rt"]
 
-# Note: We use the xC package because it has the least amount of available resources.
-default = [ "rt", "xC-package" ]
+default = [ "rt" ]
 
 [dev-dependencies]
 cortex-m-rtfm = "0.5"

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -197,7 +197,7 @@ macro_rules! hal {
                     // START and prepare to send `bytes`
                     self.i2c.cr2.write(|w| unsafe {
                         w.sadd()
-                            .bits(addr as u16) // u pto 9 bits for address
+                            .bits((addr as u16) << 1)
                             .rd_wrn()
                             .clear_bit()
                             .nbytes()
@@ -248,7 +248,7 @@ macro_rules! hal {
                     buffer: &mut [u8],) -> Result<(), Error> {
                     self.i2c.cr2.write(|w| unsafe {
                         w.sadd()
-                            .bits(addr as u16)
+                            .bits((addr as u16) << 1)
                             .rd_wrn()
                             .set_bit()
                             .nbytes()
@@ -289,7 +289,7 @@ macro_rules! hal {
                     // START and prepare to send `bytes`
                     self.i2c.cr2.write(|w| unsafe {
                         w.sadd()
-                            .bits(addr as u16)
+                            .bits((addr as u16) << 1)
                             .rd_wrn()
                             .clear_bit()
                             .nbytes()
@@ -315,7 +315,7 @@ macro_rules! hal {
                     // reSTART and prepare to receive bytes into `buffer`
                     self.i2c.cr2.write(|w| unsafe {
                         w.sadd()
-                            .bits(addr as u16)
+                            .bits((addr as u16) << 1)
                             .rd_wrn()
                             .set_bit()
                             .nbytes()

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -210,5 +210,5 @@ fn bcd2_to_byte(bcd: (u8, u8)) -> u8 {
 
     let tmp = ((value & 0xF0) >> 0x4) * 10;
 
-    (tmp + (value & 0x0F))
+    tmp + (value & 0x0F)
 }

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -28,7 +28,7 @@ unsafe impl UsbPeripheral for Peripheral {
     const EP_MEMORY_SIZE: usize = 1024;
 
     fn enable() {
-        let rcc = unsafe { (&*RCC::ptr()) };
+        let rcc = unsafe { &*RCC::ptr() };
 
         cortex_m::interrupt::free(|_| {
             // Enable USB peripheral


### PR DESCRIPTION
Fix the same issue [as in STM32L4-hal](https://github.com/stm32-rs/stm32l4xx-hal/pull/126) with 7-bit I2C addresses not being correctly shifted into the register.