### PR TITLE
RFC: Switch pac to upstream stm32-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2018"
 cortex-m = "0.7"
 embedded-dma = "0.1"
 nb = "0.1.1"
-stm32wb-pac = "0.2"
+stm32wb = "0.13.0"
 as-slice = "0.1"
 bit_field = "0.10.0"
 heapless = "0.5.3"
@@ -56,11 +56,11 @@ optional = true
 
 [features]
 
-xC-package = []
-xE-package = []
-xG-package = []
+xC-package = ["stm32wb/stm32wb55"]
+xE-package = ["stm32wb/stm32wb55"]
+xG-package = ["stm32wb/stm32wb55"]
 
-rt = ["stm32wb-pac/rt"]
+rt = ["stm32wb/rt"]
 
 default = [ "rt" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,3 +81,6 @@ codegen-units = 1
 codegen-units = 1
 debug = true
 lto = true
+
+[package.metadata.docs.rs]
+features = ["xG-package", "stm32-usbd"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ rt = ["stm32wb/rt"]
 default = [ "rt" ]
 
 [dev-dependencies]
-cortex-m-rtfm = "0.5"
+cortex-m-rtic = {version = "0.5", default-features = false, features = ["cortex-m-7"] }
 panic-halt = "0.2.0"
 panic-semihosting = "0.5.0"
 cortex-m-semihosting = { version = "0.3.5", features = ["jlink-quirks"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ embedded-dma = "0.1"
 nb = "0.1.1"
 stm32wb-pac = "0.2"
 as-slice = "0.1"
-cortex-m-semihosting = { version = "0.3.5", features = ["jlink-quirks"] }
 bit_field = "0.10.0"
 heapless = "0.5.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 edition = "2018"
 
 [dependencies]
-cortex-m = "0.6.2"
+cortex-m = "0.7"
 embedded-dma = "0.1"
 nb = "0.1.1"
 stm32wb-pac = "0.2"

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -95,12 +95,11 @@ pub struct AF14;
 /// Alternate function 15 (type state)
 pub struct AF15;
 
-#[allow(non_camel_case_types)]
 #[derive(Debug, PartialEq)]
 pub enum Edge {
-    RISING,
-    FALLING,
-    RISING_FALLING,
+    Rising,
+    Falling,
+    RisingFalling,
 }
 
 /// External Interrupt Pin
@@ -318,15 +317,15 @@ macro_rules! gpio {
                 /// Generate interrupt on rising edge, falling edge or both
                 fn trigger_on_edge(&mut self, exti: &mut EXTI, edge: Edge) {
                     match edge {
-                        Edge::RISING => {
+                        Edge::Rising => {
                             exti.rtsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                             exti.ftsr1.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << self.i)) });
                         },
-                        Edge::FALLING => {
+                        Edge::Falling => {
                             exti.ftsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                             exti.rtsr1.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << self.i)) });
                         },
-                        Edge::RISING_FALLING => {
+                        Edge::RisingFalling => {
                             exti.rtsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                             exti.ftsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                         }
@@ -583,15 +582,15 @@ macro_rules! gpio {
                     /// Generate interrupt on rising edge, falling edge or both
                     fn trigger_on_edge(&mut self, exti: &mut EXTI, edge: Edge) {
                         match edge {
-                            Edge::RISING => {
+                            Edge::Rising => {
                                 exti.rtsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                                 exti.ftsr1.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << $i)) });
                             },
-                            Edge::FALLING => {
+                            Edge::Falling => {
                                 exti.ftsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                                 exti.rtsr1.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << $i)) });
                             },
-                            Edge::RISING_FALLING => {
+                            Edge::RisingFalling => {
                                 exti.rtsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                                 exti.ftsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                             }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -334,12 +334,12 @@ macro_rules! gpio {
 
                 /// Enable external interrupts from this pin.
                 fn enable_interrupt(&mut self, exti: &mut EXTI) {
-                    exti.c1imr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
+                    exti.imr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                 }
 
                 /// Disable external interrupts from this pin
                 fn disable_interrupt(&mut self, exti: &mut EXTI) {
-                    exti.c1imr1.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << self.i)) });
+                    exti.imr1.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << self.i)) });
                 }
 
                 /// Clear the interrupt pending bit for this pin
@@ -599,12 +599,12 @@ macro_rules! gpio {
 
                     /// Enable external interrupts from this pin. CPU1.
                     fn enable_interrupt(&mut self, exti: &mut EXTI) {
-                        exti.c1imr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
+                        exti.imr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                     }
 
                     /// Disable external interrupts from this pin CPU1.
                     fn disable_interrupt(&mut self, exti: &mut EXTI) {
-                        exti.c1imr1.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << $i)) });
+                        exti.imr1.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << $i)) });
                     }
 
                     /// Clear the interrupt pending bit for this pin

--- a/src/ipcc.rs
+++ b/src/ipcc.rs
@@ -1,5 +1,5 @@
 use crate::rcc::Rcc;
-use stm32wb_pac::IPCC;
+use crate::pac::{self, IPCC};
 
 #[derive(Debug, Copy, Clone)]
 #[repr(C)]
@@ -57,8 +57,8 @@ impl Ipcc {
             .c1cr
             .modify(|_, w| w.rxoie().set_bit().txfie().set_bit());
         unsafe {
-            cortex_m::peripheral::NVIC::unmask(stm32wb_pac::interrupt::IPCC_C1_RX_IT);
-            cortex_m::peripheral::NVIC::unmask(stm32wb_pac::interrupt::IPCC_C1_TX_IT);
+            cortex_m::peripheral::NVIC::unmask(pac::interrupt::IPCC_C1_RX_IT);
+            cortex_m::peripheral::NVIC::unmask(pac::interrupt::IPCC_C1_TX_IT);
         }
     }
 
@@ -196,12 +196,12 @@ impl Ipcc {
 
     pub fn c1_is_active_flag(&self, channel: IpccChannel) -> bool {
         match channel {
-            IpccChannel::Channel1 => self.rb.c1to2sr.read().ch1f().bit(),
-            IpccChannel::Channel2 => self.rb.c1to2sr.read().ch2f().bit(),
-            IpccChannel::Channel3 => self.rb.c1to2sr.read().ch3f().bit(),
-            IpccChannel::Channel4 => self.rb.c1to2sr.read().ch4f().bit(),
-            IpccChannel::Channel5 => self.rb.c1to2sr.read().ch5f().bit(),
-            IpccChannel::Channel6 => self.rb.c1to2sr.read().ch6f().bit(),
+            IpccChannel::Channel1 => self.rb.c1toc2sr.read().ch1f().bit(),
+            IpccChannel::Channel2 => self.rb.c1toc2sr.read().ch2f().bit(),
+            IpccChannel::Channel3 => self.rb.c1toc2sr.read().ch3f().bit(),
+            IpccChannel::Channel4 => self.rb.c1toc2sr.read().ch4f().bit(),
+            IpccChannel::Channel5 => self.rb.c1toc2sr.read().ch5f().bit(),
+            IpccChannel::Channel6 => self.rb.c1toc2sr.read().ch6f().bit(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,8 @@
 #![no_std]
 
 pub use embedded_hal as hal;
-pub use stm32wb_pac as pac;
+/// TODO Eventually, this has to be fixed to be features picking
+pub use stm32wb::stm32wb55 as pac;
 
 #[cfg(feature = "rt")]
 pub use self::pac::interrupt;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,7 +7,7 @@ pub use embedded_hal::digital::v2::OutputPin;
 pub use crate::datetime::U32Ext as _stm32wb_hal_datetime_U32Ext;
 pub use crate::ipcc::IpccExt as _stm32wb_hal_ipcc_IpccExt;
 //pub use crate::dma::DmaExt as _stm32wb_hal_DmaExt;
-//pub use crate::flash::FlashExt as _stm32wb_hal_FlashExt;
+pub use crate::flash::FlashExt as _stm32wb_hal_FlashExt;
 pub use crate::gpio::GpioExt as _stm32wb_hal_GpioExt;
 pub use crate::pwm::PwmExt1 as _stm32l4_hal_PwmExt1;
 pub use crate::pwm::PwmExt2 as _stm32l4_hal_PwmExt2;

--- a/src/pwr.rs
+++ b/src/pwr.rs
@@ -1,18 +1,20 @@
+use crate::pac;
+
 /// Enables or disables USB power supply.
 pub fn set_usb(enable: bool) {
-    let pwr = unsafe { &*stm32wb_pac::PWR::ptr() };
+    let pwr = unsafe { &*pac::PWR::ptr() };
     pwr.cr2.modify(|_, w| w.usv().bit(enable));
 }
 
 /// Enables or disables CPU2 Cortex-M0 radio co-processor.
 pub fn set_cpu2(enabled: bool) {
-    let pwr = unsafe { &*stm32wb_pac::PWR::ptr() };
+    let pwr = unsafe { &*pac::PWR::ptr() };
     pwr.cr4.modify(|_, w| w.c2boot().bit(enabled))
 }
 
 /// Enables or disables access to the backup domain.
 pub fn set_backup_access(enabled: bool) {
-    let pwr = unsafe { &*stm32wb_pac::PWR::ptr() };
+    let pwr = unsafe { &*pac::PWR::ptr() };
 
     // ST: write twice the value to flush the APB-AHB bridge to ensure the bit is written
     pwr.cr1.modify(|_, w| w.dbp().bit(enabled));

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -83,7 +83,7 @@ impl Rcc {
             })
         });
 
-        // Configure SYSCLK mux to use PLL clock
+        // Configure SYSCLK mux to use selected clock
         self.rb
             .cfgr
             .modify(|_r, w| unsafe { w.sw().bits(sysclk_bits) });

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -94,7 +94,7 @@ impl Rcc {
             .modify(|_r, w| unsafe { w.sw().bits(sysclk_bits) });
 
         // Wait for SYSCLK to switch
-        while self.rb.cfgr.read().sw() != sysclk_bits {}
+        while self.rb.cfgr.read().sw().bits() != sysclk_bits {}
 
         // Configure CPU1 and CPU2 dividers
         self.clocks.hclk1 = (self.clocks.sysclk.0 / config.cpu1_hdiv.divisor()).hz();

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -51,12 +51,17 @@ impl Rcc {
             SysClkSrc::Msi(_msi_range) => todo!(),
             SysClkSrc::Hsi => todo!(),
             SysClkSrc::HseSys(hse_div) => {
-                self.clocks.hse = Some(HSE_FREQ.hz());
-
-                self.clocks.sysclk = match hse_div {
-                    HseDivider::NotDivided => HSE_FREQ.hz(),
-                    HseDivider::Div2 => (HSE_FREQ / 2).hz(),
+                // Actually turn on and use HSE....
+                let (divided, f_input) = match hse_div {
+                    HseDivider::NotDivided => (false, HSE_FREQ),
+                    HseDivider::Div2 => (true, HSE_FREQ / 2),
                 };
+                self.rb.cr.modify(|_, w| w.hsepre().bit(divided).hseon().set_bit());
+                // Wait for HSE startup
+                while !self.rb.cr.read().hserdy().bit_is_set() {}
+
+                self.clocks.hse = Some(HSE_FREQ.hz());
+                self.clocks.sysclk = f_input.hz();
 
                 0b10
             }

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -53,7 +53,7 @@ impl Rtc {
                         .clear_bit()
                 });
 
-                rtc.cr.modify(|_, w| unsafe { w.wcksel().bits(0b000) });
+                rtc.cr.modify(|_, w| unsafe { w.wucksel().bits(0b000) });
 
                 rtc.prer.modify(|_, w| unsafe {
                     w.prediv_s()

--- a/src/smps.rs
+++ b/src/smps.rs
@@ -1,20 +1,22 @@
 //! Switch-Mode Power Supply (SMPS) module
 
+use crate::pac;
+
 pub struct Smps {}
 
 impl Smps {
     pub fn enable() {
-        let pwr = unsafe { stm32wb_pac::Peripherals::steal().PWR };
+        let pwr = unsafe { pac::Peripherals::steal().PWR };
         pwr.cr5.modify(|_, w| w.sdeb().set_bit())
     }
 
     pub fn disable() {
-        let pwr = unsafe { stm32wb_pac::Peripherals::steal().PWR };
+        let pwr = unsafe { pac::Peripherals::steal().PWR };
         pwr.cr5.modify(|_, w| w.sdeb().clear_bit())
     }
 
     pub fn is_enabled() -> bool {
-        let pwr = unsafe { stm32wb_pac::Peripherals::steal().PWR };
+        let pwr = unsafe { pac::Peripherals::steal().PWR };
         pwr.cr5.read().sdeb().bit()
     }
 }

--- a/src/tl_mbox/evt.rs
+++ b/src/tl_mbox/evt.rs
@@ -1,3 +1,4 @@
+use crate::pac;
 use crate::tl_mbox::cmd::{AclDataPacket, AclDataSerial};
 use crate::tl_mbox::consts::TlPacketType;
 use crate::tl_mbox::{PacketHeader, TL_EVT_HEADER_SIZE};
@@ -171,7 +172,7 @@ impl Drop for EvtBox {
     fn drop(&mut self) {
         use crate::ipcc::IpccExt;
 
-        let mut ipcc = unsafe { stm32wb_pac::Peripherals::steal() }
+        let mut ipcc = unsafe { pac::Peripherals::steal() }
             .IPCC
             .constrain();
         super::mm::evt_drop(self.ptr, &mut ipcc);

--- a/src/tl_mbox/lhci.rs
+++ b/src/tl_mbox/lhci.rs
@@ -1,3 +1,4 @@
+use crate::pac;
 use crate::tl_mbox::cmd::CmdPacket;
 use crate::tl_mbox::consts::TlPacketType;
 use crate::tl_mbox::evt::{CcEvt, EvtPacket, EvtSerial};
@@ -47,7 +48,7 @@ impl LhciC1DeviceInformationCcrp {
             wireless_fw_info_table,
         } = unsafe { &*(&*TL_REF_TABLE.as_ptr()).device_info_table }.clone();
 
-        let dbgmcu = unsafe { stm32wb_pac::Peripherals::steal() }.DBGMCU;
+        let dbgmcu = unsafe { pac::Peripherals::steal() }.DBGMCU;
         let rev_id = dbgmcu.idcode.read().rev_id().bits();
         let dev_code_id = dbgmcu.idcode.read().dev_id().bits();
 


### PR DESCRIPTION
This is built on my other patch series, and switches to "upstream" stm32-rs pac.

The _real_ change here is all in https://github.com/eupn/stm32wb-hal/commit/c1e3a1c37fac8a86cf772d5347e19a656281198c

It _depends_ on either https://github.com/stm32-rs/stm32-rs/pull/624 or https://github.com/stm32-rs/stm32-rs/pull/473 so it's only an RFC at the moment.  When/If those merge/release, the deps can be properly updated to a real version, instead of me having a local crate source override.

I've tested this with downstream examples from the eupn/stm32wb55 repo (BTLE ibeacon was a quick one) and also some other downstream apps using this hal.

I know this effectively obsoletes a chunk of your own work, and I'm not trying to step on your toes or anything, but it seems like the PAC layer at least could come  from the stm32-rs project and get us a lot of work done for free.